### PR TITLE
Add action to run terraform apply on pushes to master

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,13 +6,12 @@ on:
       - master
 
 jobs:
-  terraform:
+  terraform-plan:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      repository-projects: write
-      id-token: write
+    outputs:
+      init-status: ${{ steps.init.outcome }}
+      plan-status: ${{ steps.plan.outcome }}
+      plan: ${{ steps.plan.outputs.plan }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -20,7 +19,8 @@ jobs:
         uses: hashicorp/setup-terraform@v1
       - name: Terraform init
         id: init
-        run: ./scripts/terraform.sh init -no-color
+        run: |
+          ./scripts/terraform.sh init -no-color
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           HCLOUD_DNS_TOKEN: ${{ secrets.HCLOUD_DNS_TOKEN }}
@@ -29,22 +29,37 @@ jobs:
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       - name: Terraform plan
         id: plan
-        run: ./scripts/terraform.sh plan -no-color
+        run: |
+          terraform_plan=$(./scripts/terraform.sh plan -no-color)
+          echo "plan=${terraform_plan}" >> "$GITHUB_OUTPUT"
+
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           HCLOUD_DNS_TOKEN: ${{ secrets.HCLOUD_DNS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      id-token: write
+    needs: terraform-plan
+    steps:
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2
         env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+          INIT_STATUS: ${{ needs.terraform-plan.outputs.init-status }}
+          PLAN_STATUS: ${{ needs.terraform-plan.outputs.plan-status }}
+          PLAN: ${{ needs.terraform-plan.outputs.plan }}
         with:
           comment_tag: execution
           message: |
-            #### Terraform Initialization: `${{ steps.init.outcome }}`
-            #### Terraform Plan: `${{ steps.plan.outcome }}`
+            #### Terraform Initialization: `$INIT_STATUS`
+            #### Terraform Plan: `$PLAN_STATUS`
             
             <details>
             <summary>Show Plan</summary>

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,11 +52,18 @@ jobs:
       id-token: write
     needs: terraform-plan
     steps:
+      - name: Prepare comment
+        env:
+          INIT_STATUS: ${{ env.INIT_STATUS }}
+          PLAN_STATUS: ${{ env.PLAN_STATUS }}
+        run: |
+          echo 'INIT_STATUS=$([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")' >> "$GITHUB_OUTPUT"
+          echo 'PLAN_STATUS=$([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")' >> "$GITHUB_OUTPUT"
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2
         env:
-          INIT_STATUS: $([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")
-          PLAN_STATUS: $([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")
+          INIT_STATUS: ${{ env.INIT_STATUS }}
+          PLAN_STATUS: ${{ env.PLAN_STATUS }}
           PLAN: ${{ needs.terraform-plan.outputs.plan }}
         with:
           comment_tag: execution

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,23 +53,24 @@ jobs:
     needs: terraform-plan
     steps:
       - name: Prepare comment
+        id: prepare
         env:
-          INIT_STATUS: ${{ env.INIT_STATUS }}
-          PLAN_STATUS: ${{ env.PLAN_STATUS }}
+          INIT_STATUS: ${{ needs.terraform-plan.outputs.init-status }}
+          PLAN_STATUS: ${{ needs.terraform-plan.outputs.plan-status }}
         run: |
-          echo 'INIT_STATUS=$([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")' >> "$GITHUB_OUTPUT"
-          echo 'PLAN_STATUS=$([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")' >> "$GITHUB_OUTPUT"
+          INIT_STATUS_ICON=$([[ "$INIT_STATUS" == "success" ]] && echo "✅" || echo "❌")
+          echo "INIT_STATUS_ICON=$INIT_STATUS_ICON" >> "$GITHUB_OUTPUT"
+          PLAN_STATUS_ICON=$([[ "$PLAN_STATUS" == "success" ]] && echo "✅" || echo "❌")
+          echo "PLAN_STATUS_ICON=$PLAN_STATUS_ICON" >> "$GITHUB_OUTPUT"
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2
         env:
-          INIT_STATUS: ${{ env.INIT_STATUS }}
-          PLAN_STATUS: ${{ env.PLAN_STATUS }}
           PLAN: ${{ needs.terraform-plan.outputs.plan }}
         with:
           comment_tag: execution
           message: |
-            #### Terraform Init: `${{ env.INIT_STATUS }}`
-            #### Terraform Plan: `${{ env.PLAN_STATUS }}`
+            #### Terraform Init: `${{ steps.prepare.outputs.INIT_STATUS_ICON }}`
+            #### Terraform Plan: `${{ steps.prepare.outputs.PLAN_STATUS_ICON }}`
             
             <details>
             <summary>Show Plan</summary>

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,8 +61,8 @@ jobs:
         with:
           comment_tag: execution
           message: |
-            #### Terraform Initialization: `$INIT_STATUS`
-            #### Terraform Plan: `$PLAN_STATUS`
+            #### Terraform Init: `$([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")`
+            #### Terraform Plan: `$([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")`
             
             <details>
             <summary>Show Plan</summary>

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,14 +55,14 @@ jobs:
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2
         env:
-          INIT_STATUS: ${{ needs.terraform-plan.outputs.init-status }}
-          PLAN_STATUS: ${{ needs.terraform-plan.outputs.plan-status }}
+          INIT_STATUS: $([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")
+          PLAN_STATUS: $([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")
           PLAN: ${{ needs.terraform-plan.outputs.plan }}
         with:
           comment_tag: execution
           message: |
-            #### Terraform Init: `$([[ ${{ env.INIT_STATUS }} == "success" ]] && echo "✅" || echo "❌")`
-            #### Terraform Plan: `$([[ ${{ env.PLAN_STATUS }} == "success" ]] && echo "✅" || echo "❌")`
+            #### Terraform Init: `${{ env.INIT_STATUS }}`
+            #### Terraform Plan: `${{ env.PLAN_STATUS }}`
             
             <details>
             <summary>Show Plan</summary>

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,8 +31,11 @@ jobs:
         id: plan
         run: |
           terraform_plan=$(./scripts/terraform.sh plan -no-color)
-          echo "plan=${terraform_plan}" >> "$GITHUB_OUTPUT"
-
+          {
+            echo "plan<<EOF"
+            echo "$terraform_plan"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           HCLOUD_DNS_TOKEN: ${{ secrets.HCLOUD_DNS_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,11 +57,15 @@ jobs:
         env:
           INIT_STATUS: ${{ needs.terraform-plan.outputs.init-status }}
           PLAN_STATUS: ${{ needs.terraform-plan.outputs.plan-status }}
+          PLAN: ${{ needs.terraform-plan.outputs.plan }}
         run: |
-          INIT_STATUS_ICON=$([[ "$INIT_STATUS" == "success" ]] && echo "✅" || echo "❌")
-          echo "INIT_STATUS_ICON=$INIT_STATUS_ICON" >> "$GITHUB_OUTPUT"
-          PLAN_STATUS_ICON=$([[ "$PLAN_STATUS" == "success" ]] && echo "✅" || echo "❌")
-          echo "PLAN_STATUS_ICON=$PLAN_STATUS_ICON" >> "$GITHUB_OUTPUT"
+          icon=$([[ "$INIT_STATUS" == "success" ]] && echo "✅" || echo "❌")
+          echo "INIT_STATUS_TEXT=$icon" >> "$GITHUB_OUTPUT"
+          
+          icon=$([[ "$PLAN_STATUS" == "success" ]] && echo "✅" || echo "❌")
+          updates=$(echo "$PLAN" | grep -oP "^Plan: \K.*")
+          text="${icon} ${updates}"
+          echo "PLAN_STATUS_TEXT=$text" >> "$GITHUB_OUTPUT"
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2
         env:
@@ -69,8 +73,8 @@ jobs:
         with:
           comment_tag: execution
           message: |
-            #### Terraform Init: `${{ steps.prepare.outputs.INIT_STATUS_ICON }}`
-            #### Terraform Plan: `${{ steps.prepare.outputs.PLAN_STATUS_ICON }}`
+            #### Terraform Init: `${{ steps.prepare.outputs.INIT_STATUS_TEXT }}`
+            #### Terraform Plan: `${{ steps.prepare.outputs.PLAN_STATUS_TEXT }}`
             
             <details>
             <summary>Show Plan</summary>

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,58 @@
+name: Push to Master
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: # allow manual triggering
+
+jobs:
+  terraform-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Terraform setup
+        uses: hashicorp/setup-terraform@v1
+      - name: Terraform init
+        id: init
+        run: |
+          ./scripts/terraform.sh init -no-color
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          HCLOUD_DNS_TOKEN: ${{ secrets.HCLOUD_DNS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      - name: Terraform plan
+        id: plan
+        run: |
+          ./scripts/terraform.sh plan -no-color -out terraform-plan.txt
+          plan=$(cat terraform-plan.txt)
+          {
+            echo "plan<<EOF"
+            echo "$terraform_plan"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          HCLOUD_DNS_TOKEN: ${{ secrets.HCLOUD_DNS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      - name: Upload plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan.txt
+
+  terraform-apply:
+    runs-on: ubuntu-latest
+    needs: terraform-plan
+    steps:
+      - name: Download plan
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-plan.txt
+      - name: Terraform apply
+        run: |
+          ./scripts/terraform.sh apply terraform-plan.txt


### PR DESCRIPTION
## If applied, this PR will ...

- add action to apply terraform on push to master
- split terraform plan and comment into separate jobs

## Why is this change needed?

- we want to automatically apply terraform on pushes to master to ensure the actual infrastructure and the state of the repo are in sync
- the split is a preparation for easiser reuse of logic later on