### PR TITLE
fix: fix mounting volume

### DIFF
--- a/terraform/cloud-init.d/init.sh
+++ b/terraform/cloud-init.d/init.sh
@@ -2,12 +2,10 @@
 set -euo pipefail
 
 # Wait for volume to be mounted
-sleep 20
-
 while true; do
-    mountpoint=$(mount | grep "HC_Volume" | awk '{print $3}')
-    if [[ -z "$mountpoint" ]]; then
-        echo "Waiting for mountpoint to be available..."
+    mountpoint=$(findmnt -rno TARGET /mnt/HC_Volume_* || true)
+    if [[ -z "$${mountpoint:-}" ]]; then
+        echo "Waiting for volume to be mounted..."
         sleep 10
     else
         break
@@ -15,7 +13,6 @@ while true; do
 done
 
 # Create symlink to mounted volume
-mkdir -p /mnt/data
 ln -s $mountpoint /mnt/data
 
 # update config


### PR DESCRIPTION
## If applied, this PR will ...

- fix mounting the dir on the cloud init step
- speedup the initialization logic by removing the hardcoded 20 s sleep before first checking if the volume is mounted

## Why is this change needed?

- it's still broken since #7, because of the following issues:
  - `mountpoint=$(mount | grep "HC_Volume" | awk '{print $3}')`: could return an error and cause the script to fail (due to `set -e`)
  - the symlink was created inside the dir `/mnt/data` instead of replacing the exact dir, e.g. `/mnt/data/HC_Volume_...`
