### PR TITLE
Improve security for SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,10 @@ TODO: describe usage
 
 - bootstrap
 - backups: litestream to s3 bucket?
-- github actions -> apply terraform nightly (store secrets in GH secrets) or on pushes to main, plan on PRs
 - renovate/dependabot
 - manage dns zone completely via terraform
 - tag all resources with the source repo
 - check if "env_file" can be removed from docker compose file
 - replace domain in docker-compose with envsubst
 - sandbox env
-- troubleshoot if (and if yes why) mounting the volume fails after the first server with a new packer build
-- server hardening: fail2ban, disable root login, etc.
-
-- note: dependencies: 1. ssh key, 2. aws creds
+- traefik monitoring with crowdsec

--- a/packer/install.sh
+++ b/packer/install.sh
@@ -14,6 +14,14 @@ apt-get install --yes \
     unzip \
     jq
 
+# crowdsec
+curl -fsSL https://packagecloud.io/crowdsec/crowdsec/gpgkey | gpg --dearmor > /etc/apt/keyrings/crowdsec.gpg
+echo "deb [signed-by=/etc/apt/keyrings/crowdsec.gpg] https://packagecloud.io/crowdsec/crowdsec/any/ any main" \
+    > "/etc/apt/sources.list.d/crowdsec.list"
+
+apt-get update
+apt-get install --yes crowdsec crowdsec-firewall-bouncer-iptables
+
 # aws cli
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
@@ -31,7 +39,7 @@ add-apt-repository \
 
 apt-get update
 apt-get dist-upgrade --yes
-apt-get install docker-ce docker-ce-cli containerd.io docker-compose --yes
+apt-get install --yes docker-ce docker-ce-cli containerd.io docker-compose
 
 systemctl enable docker
 systemctl start docker

--- a/terraform/cloud-init.d/init.tpl
+++ b/terraform/cloud-init.d/init.tpl
@@ -5,6 +5,12 @@ package_update: false
 package_upgrade: false
 package_reboot_if_required: false
 
+# Lock down ssh
+ssh_pwauth: false
+
+runcmd:
+  - systemctl restart sshd
+
 write_files:
 - path: /etc/profile
   append: true


### PR DESCRIPTION
## If applied, this PR will ...

- disable password auth for ssh access
- install crowdsec along with the bouncer `crowdsec-firewall-bouncer-iptables` which blocks malicious IP addresses by creating firewall rules with iptables
  - we use the default config which blocks IP addresses that:
    1. fail to login multiple times in a short time frame (reactive block)
    2. were blocked by other users/servers using crowdsec (preemptive block)

## Why is this change needed?

- SSH key are more secure than passwords and we already use them. This PR enforces them
- every public internet facing server is constantly seeing login attempts from malicious actors (mostly brute force attacks or trying out known vulnerabilities). Crowdsec makes such attacks much more expensive for the attackers by forcing them to slow down their attack or requiring to use lots of different IP addresses
