### PR TITLE
fix: resolve automount not working anymore

### DIFF
--- a/terraform/cloud-init.d/init.tpl
+++ b/terraform/cloud-init.d/init.tpl
@@ -8,8 +8,8 @@ package_reboot_if_required: false
 # Lock down ssh
 ssh_pwauth: false
 
-runcmd:
-  - systemctl restart sshd
+# Don't use runcmd, because otherwise automounting the volume won't work anymore, see:
+# https://github.com/hetznercloud/terraform-provider-hcloud/issues/473
 
 write_files:
 - path: /etc/profile


### PR DESCRIPTION
## If applied, this PR will ...

- fix automounting the volume

## Why is this change needed?

- automount stopped working after the changes made in #9 due to an unexpected behavior in the way Hetzner handles automounting, see https://github.com/hetznercloud/terraform-provider-hcloud/issues/473#issuecomment-971535629
