### PR TITLE
chore: bump version of setup-terraform

### DIFF
--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform init
         id: init
         run: |
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform init
         id: init
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform init
         id: init
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform init
         id: init
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform init
         id: init
         run: |


### PR DESCRIPTION
- bump `setup-terraform`
- fixes the `set-output` deprecation warnings in the logs