### PR TITLE
Enable automerge for dependabot PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,3 +84,13 @@ jobs:
             ```
             
             </details>
+
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## If applied, this PR will ...

- enable automerge for dependabot PRs

## Why is this change needed?

- dependency updates can be applied automatically
