### PR TITLE
fix: add required write permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  permissions:
+    contents: write
+    pull-requests: write
 
 permissions:
   contents: write


### PR DESCRIPTION
## If applied, this PR will ...

- add write permissions to PR action

## Why is this change needed?

- required to automerge PRs from dependabot
