### PR TITLE
chore: update dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,14 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
-  - package-ecosystem: "docker"
+  - package-ecosystem: "docker-compose"
     directory: "/config"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/config"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## If applied, this PR will ...

- update dependabot rules:
  - fix `docker` rule by using `docker-compose` instead
  - add rule for Github actions
  - increase update frequency

## Why is this change needed?

- `docker` rule is only for Dockerfiles
- Github action should also get updated 

