### PR TITLE
Fix Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "github-actions"
-    directory: "/config"
+    directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,8 +96,10 @@ jobs:
       - terraform-plan
       - comment
     steps:
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Authenticate cli with a PAT
+        run: echo "${{ secrets.DEPENDABOT_TOKEN }}" | gh auth login --with-token
+        # use PAT to trigger other actions, see: https://github.com/dependabot/fetch-metadata/issues/111
+      - name: Auto-merge Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## If applied, this PR will ...

- fix Dependabot rule for updating Github actions
- use PAT for merging Dependabot PRs

## Why is this change needed?

- rule for Github actions is configured incorrectly
- default token doesn't trigger the `push` action after merging a Dependabot PR into master
