### PR TITLE
chore: limit automerge to non-major dependency updates

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,10 +96,14 @@ jobs:
       - terraform-plan
       - comment
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
       - name: Authenticate cli with a PAT
         run: echo "${{ secrets.DEPENDABOT_TOKEN }}" | gh auth login --with-token
         # use PAT to trigger other actions, see: https://github.com/dependabot/fetch-metadata/issues/111
-      - name: Auto-merge Dependabot PRs
+      - name: Auto-merge non-major dependency updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## If applied, this PR will ...

- limit automerge to non-major dependency updates

## Why is this change needed?

- major dependency updates should be merged manually
