### PR TITLE
chore: include packer in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "terraform"
+    directory: "/packer"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "docker-compose"
     directory: "/config"
     schedule:


### PR DESCRIPTION
## If applied, this PR will ...

- include packer in dependabot updates

## Why is this change needed?

- packer dependencies are currently not updated
