### PR TITLE
Tag packer builds with name

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -20,20 +20,21 @@ variable "aws_secret_access_key" {
   sensitive = true
 }
 
-source "hcloud" "base-amd64" {
+source "hcloud" "this" {
   image         = "ubuntu-24.04"
   location      = "fsn1"
   server_type   = "cx22"
   user_data     = ""
   ssh_username  = "root"
-  snapshot_name = "base-{{isotime `10060102150405`}}"
+  snapshot_name = "personal-projects-base-{{isotime `2006-01-02`}}"
   snapshot_labels = {
     source = "packer"
+    name = "personal-projects"
   }
 }
 
 build {
-  sources = ["source.hcloud.base-amd64"]
+  sources = ["source.hcloud.this"]
 
   provisioner "shell" {
     execute_command = "sudo -S env {{ .Vars }} {{ .Path }}"

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,6 +1,6 @@
 
 data "hcloud_image" "this" {
-    with_selector = "source=packer"
+    with_selector = "source=packer,name=personal-projects"
     most_recent = true
 }
 

--- a/terraform/server.tf
+++ b/terraform/server.tf
@@ -1,6 +1,6 @@
 
 resource "hcloud_server" "projects-server" {
-    name = "projects-server"
+    name = "personal-projects"
     server_type = "cx22"
     image = data.hcloud_image.this.id
     location = "fsn1"


### PR DESCRIPTION
## If applied, this PR will ...

- tag packer builds with name
- improve naming

## Why is this change needed?

- required to support managing multiple terraform/packer setups in the same Hetzner account
