### PR TITLE
chore: remove packer from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "terraform"
-    directory: "/packer"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "docker-compose"
     directory: "/config"
     schedule:


### PR DESCRIPTION
## If applied, this PR will ...

- remove packer from dependabot updates

## Why is this change needed?

- `terraform` ecosystem doesn't support updates for packer
