### PR TITLE
chore: set name which is needed for statuscheck

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   terraform-plan:
+    name: terraform-plan
     runs-on: ubuntu-latest
     outputs:
       init-status: ${{ steps.init.outcome }}


### PR DESCRIPTION
## If applied, this PR will ...

- fix statuscheck by setting the name the check is expecting

## Why is this change needed?

- currently PRs can't be merged, because the statuscheck is waiting for a status with a different name
