### PR TITLE
feat: add source label to all resources

### DIFF
--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -1,6 +1,7 @@
 
 resource "hcloud_firewall" "basic" {
-  name = "basic"
+  name   = "basic"
+  labels = local.resource_labels
 
   rule {
     description = "allow ssh"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,5 @@
 locals {
-
+  resource_labels = {
+    source = "christianwaldmann-personal-projects"
+  }
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -2,6 +2,7 @@
 resource "hcloud_network" "this" {
   name     = "private-network"
   ip_range = "10.0.0.0/8"
+  labels   = local.resource_labels
 }
 
 resource "hcloud_network_subnet" "this" {

--- a/terraform/server.tf
+++ b/terraform/server.tf
@@ -11,4 +11,5 @@ resource "hcloud_server" "this" {
   firewall_ids = [
     hcloud_firewall.basic.id
   ]
+  labels = local.resource_labels
 }

--- a/terraform/ssh.tf
+++ b/terraform/ssh.tf
@@ -2,4 +2,5 @@
 resource "hcloud_ssh_key" "default" {
   name       = "Personal Key"
   public_key = var.ssh_public_key
+  labels     = local.resource_labels
 }

--- a/terraform/volume.tf
+++ b/terraform/volume.tf
@@ -6,8 +6,9 @@ resource "hcloud_volume" "this" {
   delete_protection = true # this disables the "delete" button in the Hetzner UI
 
   # Attach volume to server
-  server_id = hcloud_server.this.id
-  automount = true
+  server_id         = hcloud_server.this.id
+  automount         = true
+  labels            = local.resource_labels
 
   # prevent terraform from deleting this volume
   lifecycle {


### PR DESCRIPTION
## If applied, this PR will ...

- Add `source` label to all Hetzner Cloud resources (server, firewall, volume, network, ssh_key)

## Why is this change needed?

- Makes it easy to identify which repository manages each resource in the Hetzner Cloud console
- Listed as a TODO in README.md