### PR TITLE
fix: remove FreshRSS healthcheck

### DIFF
--- a/config/docker-compose.yaml
+++ b/config/docker-compose.yaml
@@ -88,10 +88,3 @@ services:
       - "traefik.http.routers.freshrss.entrypoints=websecure"
       - "traefik.http.routers.freshrss.tls.certresolver=myresolver"
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "cli/health.php"]
-      timeout: 10s
-      start_period: 60s
-      start_interval: 11s
-      interval: 75s
-      retries: 3


### PR DESCRIPTION
## Summary
- remove the FreshRSS healthcheck that prevents initial setup and interferes with Traefik routing
 